### PR TITLE
Fix: Update modal image to match the clicked card

### DIFF
--- a/script.js
+++ b/script.js
@@ -268,6 +268,7 @@ document.addEventListener('DOMContentLoaded', function () {
     if (modal) {
         const modalTitle = document.getElementById('modal-title');
         const modalText = document.getElementById('modal-text');
+        const modalImage = modal.querySelector('.modal-header-image');
         const closeButton = modal.querySelector('.close-button');
 
         document.body.addEventListener('click', function(e) {
@@ -291,6 +292,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 if (data) {
                     modalTitle.textContent = data.title;
                     modalText.textContent = data.description;
+                    modalImage.src = data.image;
                     modal.style.display = 'block';
                 }
             }


### PR DESCRIPTION
The modal popup was displaying a static, hardcoded image regardless of which project card was clicked.

This change modifies `script.js` to dynamically update the `src` attribute of the modal's header image. The script now retrieves the correct image URL from the corresponding data object when a card's "Read More" button is clicked, ensuring the modal displays the image associated with that specific project, news item, or announcement.