### PR TITLE
Fix: Resolve infinite loading in video gallery

### DIFF
--- a/script.js
+++ b/script.js
@@ -43,7 +43,7 @@ document.addEventListener('DOMContentLoaded', function () {
             items: [
                 { type: 'photo', src: 'https://picsum.photos/400/250?random=15', description: 'صورة من الافتتاح' },
                 { type: 'photo', src: 'https://picsum.photos/400/250?random=16', description: 'الحضور في الافتتاح' },
-                { type: 'video', src: 'https://www.w3schools.com/html/mov_bbb.mp4', description: 'فيديو قصير من الحدث' }
+                { type: 'video', src: 'https://www.w3schools.com/html/mov_bbb.mp4', thumbnail: 'https://picsum.photos/400/250?random=19', description: 'فيديو قصير من الحدث' }
             ]
         },
         {
@@ -248,9 +248,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     `;
                 } else if (item.type === 'video') {
                     galleryItem.innerHTML = `
-                        <video>
-                            <source src="${item.src}" type="video/mp4">
-                        </video>
+                        <img src="${item.thumbnail}" alt="${item.description}">
                         <div class="item-description">${item.description}</div>
                         <div class="video-play-icon"><i class="fas fa-play"></i></div>
                     `;


### PR DESCRIPTION
The video gallery was experiencing an infinite loading issue because the gallery items were being created with an HTML5 `<video>` element directly inside the anchor tag. This is incompatible with how Lightbox2 handles video content.

This commit resolves the issue by:
1.  Updating the `galleryData` in `script.js` to include a `thumbnail` property for video items.
2.  Modifying the gallery rendering logic to use this thumbnail in an `<img>` tag instead of a `<video>` element.

This ensures that a static image is displayed in the gallery, and Lightbox2 can correctly open the video file in a popup when the thumbnail is clicked.