### PR TITLE
Fix: Implement mobile menu toggle functionality

### DIFF
--- a/script.js
+++ b/script.js
@@ -364,4 +364,14 @@ document.addEventListener('DOMContentLoaded', function () {
             changeSlide(currentSlide + 1);
         }, 5000);
     });
+
+    // Mobile menu toggle
+    const menuToggle = document.querySelector('.menu-toggle');
+    const nav = document.querySelector('nav');
+
+    if (menuToggle && nav) {
+        menuToggle.addEventListener('click', () => {
+            nav.classList.toggle('active');
+        });
+    }
 });


### PR DESCRIPTION
The burger menu on mobile was not functional because the click event listener was missing.

This commit adds the necessary JavaScript to `script.js` to handle the click event on the `.menu-toggle` button. When the button is clicked, it now toggles the `.active` class on the `<nav>` element, which makes the menu visible as defined in `style.css`.