### PR TITLE
fix: Remove underline from website title

### DIFF
--- a/style.css
+++ b/style.css
@@ -51,6 +51,7 @@ header .container {
 .logo-container {
     display: flex;
     align-items: center;
+    text-decoration: none;
 }
 
 #logo {


### PR DESCRIPTION
The website title "بلدية زان" had an underline because it was part of a hyperlink. This change removes the underline by applying `text-decoration: none;` to the `.logo-container` class that wraps the title and logo in the header.

This ensures the title appears without an underline on all pages that share the common header, improving the visual consistency of the site. The change was verified by inspecting the live page and through a Playwright screenshot test.