### PR TITLE
Fix: Implement search functionality for services page

### DIFF
--- a/script.js
+++ b/script.js
@@ -378,4 +378,24 @@ document.addEventListener('DOMContentLoaded', function () {
             nav.classList.toggle('active');
         });
     }
+
+    // Handle form search on services page
+    const formSearchInput = document.getElementById('form-search');
+    const formsList = document.getElementById('forms-list');
+
+    if (formSearchInput && formsList) {
+        formSearchInput.addEventListener('input', function() {
+            const searchTerm = formSearchInput.value.toLowerCase();
+            const formItems = formsList.getElementsByClassName('form-item');
+
+            Array.from(formItems).forEach(function(item) {
+                const formName = item.querySelector('.form-name').textContent.toLowerCase();
+                if (formName.includes(searchTerm)) {
+                    item.classList.remove('hidden');
+                } else {
+                    item.classList.add('hidden');
+                }
+            });
+        });
+    }
 });


### PR DESCRIPTION
Adds client-side search functionality to the administrative services page.

The search input field now has an 'input' event listener that filters the list of forms in real-time. This is achieved by toggling a 'hidden' CSS class on the form items that do not match the search term.

The implementation follows the existing pattern for search on other pages like 'news' and 'announcements' but is adapted for the static list of forms in 'services.html'.